### PR TITLE
fix: trim casdoor enpoint

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	_ "embed"
+	"strings"
 
 	"github.com/astaxie/beego"
 	"github.com/casbin/casnode/object"
@@ -31,7 +32,7 @@ func init() {
 }
 
 func InitAuthConfig() {
-	casdoorEndpoint := beego.AppConfig.String("casdoorEndpoint")
+	casdoorEndpoint := strings.TrimRight(beego.AppConfig.String("casdoorEndpoint"), "/")
 	clientId := beego.AppConfig.String("clientId")
 	clientSecret := beego.AppConfig.String("clientSecret")
 	casdoorOrganization := beego.AppConfig.String("casdoorOrganization")


### PR DESCRIPTION
if the casnode config `casdoorEndpoint`. endwith `/`. 
SDK will call `//api/login/oauth/access_token` 

It means the `/` exists twice,  so need to trim it.