### PR TITLE
feat: Support enable cross-chain, update the Record editing page

### DIFF
--- a/object/record.go
+++ b/object/record.go
@@ -121,10 +121,23 @@ func GetRecord(id string) (*Record, error) {
 
 func UpdateRecord(id string, record *Record) (bool, error) {
 	owner, name := util.GetOwnerAndNameFromId(id)
-	if p, err := getRecord(owner, name); err != nil {
+	p, err := getRecord(owner, name)
+	if err != nil {
 		return false, err
 	} else if p == nil {
 		return false, nil
+	}
+
+	// Update provider
+	if record.Provider != p.Provider {
+		record.Block = ""
+		record.BlockHash = ""
+		record.Transaction = ""
+	}
+	if record.Provider2 != p.Provider2 {
+		record.Block2 = ""
+		record.BlockHash2 = ""
+		record.Transaction2 = ""
 	}
 
 	affected, err := adapter.engine.Where("name = ?", name).AllCols().Update(record)

--- a/object/record_chain.go
+++ b/object/record_chain.go
@@ -28,14 +28,14 @@ type Param struct {
 }
 
 func (record *Record) getRecordProvider(chainProvider string) (*Provider, error) {
-	if record.Provider != "" {
+	if chainProvider != "" {
 		provider, err := getProvider("admin", chainProvider)
 		if err != nil {
 			return nil, err
 		}
 
 		if provider == nil {
-			return nil, fmt.Errorf("The blockchain provider: %s is not found", chainProvider)
+			return nil, fmt.Errorf("the blockchain provider: %s is not found", chainProvider)
 		}
 
 		return provider, nil
@@ -94,9 +94,11 @@ func (record *Record) toMap() map[string]string {
 
 func (record *Record) toParam() string {
 	record2 := *record
+	record2.Provider = ""
 	record2.Block = ""
 	record2.Transaction = ""
 	record2.BlockHash = ""
+	record2.Provider2 = ""
 	record2.Block2 = ""
 	record2.Transaction2 = ""
 	record2.BlockHash2 = ""

--- a/web/src/RecordEditPage.js
+++ b/web/src/RecordEditPage.js
@@ -15,6 +15,7 @@
 import React from "react";
 import {Button, Card, Col, Input, Row, Select, Switch} from "antd";
 import * as RecordBackend from "./backend/RecordBackend";
+import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
 
@@ -33,12 +34,14 @@ class RecordEditPage extends React.Component {
       recordOwner: props.match.params.organizationName,
       recordName: props.match.params.recordName,
       record: null,
+      blockchainProviders: [],
       mode: props.location.mode !== undefined ? props.location.mode : "edit",
     };
   }
 
   UNSAFE_componentWillMount() {
     this.getRecord();
+    this.getProviders();
   }
 
   getRecord() {
@@ -50,6 +53,19 @@ class RecordEditPage extends React.Component {
           });
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
+        }
+      });
+  }
+
+  getProviders() {
+    ProviderBackend.getProviders(this.props.account.owner)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.setState({
+            blockchainProviders: res.data.filter(provider => provider.category === "Blockchain" && provider.state === "Active"),
+          });
+        } else {
+          Setting.showMessage("error", res.msg);
         }
       });
   }
@@ -113,9 +129,15 @@ class RecordEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Provider"), i18next.t("general:Provider - Tooltip"))} :
           </Col>
           <Col span={22}>
-            <Input disabled={false} value={this.state.record.provider} onChange={e => {
-              // this.updateRecordField("provider", e.target.value);
-            }} />
+            <Select disabled={false} virtual={false} style={{width: "100%"}} value={this.state.record.provider} onChange={(value => {
+              this.updateRecordField("provider", value);
+            })}>
+              {
+                this.state.blockchainProviders.map((provider, index) => (
+                  <Option key={index} value={provider.name}>{provider.name}</Option>
+                ))
+              }
+            </Select>
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}}>
@@ -124,7 +146,33 @@ class RecordEditPage extends React.Component {
           </Col>
           <Col span={22}>
             <Input disabled={false} value={this.state.record.block} onChange={e => {
-              this.updateRecordField("block", e.target.value);
+              // this.updateRecordField("block", e.target.value);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}}>
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("general:Provider") + " 2", i18next.t("general:Provider - Tooltip"))} :
+          </Col>
+          <Col span={22}>
+            <Select disabled={false} virtual={false} style={{width: "100%"}} value={this.state.record.provider2} onChange={(value => {
+              this.updateRecordField("provider2", value);
+            })}>
+              {
+                this.state.blockchainProviders.map((provider, index) => (
+                  <Option key={index} value={provider.name}>{provider.name}</Option>
+                ))
+              }
+            </Select>
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}}>
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("general:Block") + " 2", i18next.t("general:Block - Tooltip"))} :
+          </Col>
+          <Col span={22}>
+            <Input disabled={false} value={this.state.record.block2} onChange={e => {
+              // this.updateRecordField("block", e.target.value);
             }} />
           </Col>
         </Row>

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -478,9 +478,10 @@ class RecordListPage extends BaseListPage {
             <div>
               {i18next.t("general:Records")}
               {Setting.isAdminUser(this.props.account) && (
-                <Button type={this.state.enableCrossChain ? "primary" : "default"} size="small" onClick={this.toggleEnableCrossChain} style={{marginLeft: 16}}>
-                  {this.state.enableCrossChain ? i18next.t("record:Disable cross-chain") : i18next.t("record:Enable cross-chain")}
-                </Button>
+                <span style={{marginLeft: 16}}>
+                  {i18next.t("record:Enable cross-chain")}:
+                  <Switch checked={this.state.enableCrossChain} checkedChildren="ON" unCheckedChildren="OFF" onChange={this.toggleEnableCrossChain} style={{marginLeft: 8}} />
+                </span>
               )}
               {this.state.selectedRowKeys.length > 0 && (
                 <Popconfirm title={`${i18next.t("general:Sure to delete")}: ${this.state.selectedRowKeys.length} ${i18next.t("general:items")} ?`} onConfirm={() => this.performBulkDelete(this.state.selectedRows, this.state.selectedRowKeys)} okText={i18next.t("general:OK")} cancelText={i18next.t("general:Cancel")}>

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -478,9 +478,9 @@ class RecordListPage extends BaseListPage {
             <div>
               {i18next.t("general:Records")}
               {Setting.isAdminUser(this.props.account) && (
-                <span style={{marginLeft: 16}}>
+                <span style={{marginLeft: 32}}>
                   {i18next.t("record:Enable cross-chain")}:
-                  <Switch checked={this.state.enableCrossChain} checkedChildren="ON" unCheckedChildren="OFF" onChange={this.toggleEnableCrossChain} style={{marginLeft: 8}} />
+                  <Switch checked={this.state.enableCrossChain} checkedChildren={i18next.t("general:ON")} unCheckedChildren={i18next.t("general:OFF")} onChange={this.toggleEnableCrossChain} style={{marginLeft: 8}} />
                 </span>
               )}
               {this.state.selectedRowKeys.length > 0 && (

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Switch, Table} from "antd";
+import {Button, Popconfirm, Switch, Table, Tooltip} from "antd";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as RecordBackend from "./backend/RecordBackend";
@@ -30,12 +30,29 @@ class RecordListPage extends BaseListPage {
     this.state = {
       ...this.state,
       providerMap: {},
+      enableCrossChain: this.getEnableCrossChainFromStorage(),
     };
   }
 
   componentDidMount() {
     this.getProviders();
   }
+
+  getEnableCrossChainFromStorage() {
+    const saved = localStorage.getItem("enableCrossChain");
+    if (saved === null || saved === undefined) {
+      return false;
+    }
+    return JSON.parse(saved) === true;
+  }
+
+  toggleEnableCrossChain = () => {
+    const newValue = !this.state.enableCrossChain;
+    this.setState({
+      enableCrossChain: newValue,
+    });
+    localStorage.setItem("enableCrossChain", JSON.stringify(newValue));
+  };
 
   getProviders() {
     ProviderBackend.getProviders(this.props.account.owner)
@@ -232,7 +249,7 @@ class RecordListPage extends BaseListPage {
           );
         },
       },
-      {
+      (this.state.enableCrossChain ? {
         title: i18next.t("vector:Provider") + " 2",
         dataIndex: "provider2",
         key: "provider2",
@@ -248,7 +265,10 @@ class RecordListPage extends BaseListPage {
             </Link>
           );
         },
-      },
+      } : {
+        title: i18next.t("vector:Provider") + " 2",
+        hidden: true,
+      }),
       {
         title: i18next.t("general:User"),
         dataIndex: "user",
@@ -347,7 +367,7 @@ class RecordListPage extends BaseListPage {
         title: i18next.t("general:Block"),
         dataIndex: "block",
         key: "block",
-        width: "100px",
+        width: "110px",
         sorter: true,
         fixed: (Setting.isMobile()) ? "false" : "right",
         ...this.getColumnSearchProps("block"),
@@ -355,33 +375,42 @@ class RecordListPage extends BaseListPage {
           return Setting.getBlockBrowserUrl(this.state.providerMap, record, text, true);
         },
       },
-      {
+      (this.state.enableCrossChain ? {
         title: i18next.t("general:Block") + " 2",
         dataIndex: "block2",
         key: "block2",
-        width: "100px",
+        width: "110px",
         sorter: true,
         fixed: (Setting.isMobile()) ? "false" : "right",
         ...this.getColumnSearchProps("block2"),
         render: (text, record, index) => {
           return Setting.getBlockBrowserUrl(this.state.providerMap, record, text, false);
         },
-      },
+      } : {
+        title: i18next.t("general:Block") + " 2",
+        hidden: true,
+      }),
       {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "360px",
+        width: this.state.enableCrossChain ? "370px" : "270px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
+            <div style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "10px",
+              alignItems: "center",
+              marginTop: "10px",
+              marginBottom: "10px",
+            }}>
               {
                 <>
                   {(record.block === "") ? (
                     <Button
                       disabled={record.block !== ""}
-                      style={{marginTop: "10px", marginRight: "10px"}}
                       type="primary" danger
                       onClick={() => this.commitRecord(index, true)}
                     >{i18next.t("record:Commit")}
@@ -389,25 +418,24 @@ class RecordListPage extends BaseListPage {
                   ) : (
                     <Button
                       disabled={record.block === ""}
-                      style={{marginTop: "10px", marginRight: "10px"}}
                       type="primary"
                       onClick={() => this.queryRecord(record, true)}
                     >{i18next.t("record:Query")}
                     </Button>
                   )}
-                  {record.provider2 && record.provider2 !== "" && (
+                  {this.state.enableCrossChain && (
                     (record.block2 === "") ? (
-                      <Button
-                        disabled={record.block2 !== ""}
-                        style={{marginTop: "10px", marginRight: "10px"}}
-                        type="primary" danger
-                        onClick={() => this.commitRecord(index, false)}
-                      >{i18next.t("record:Commit") + " 2"}
-                      </Button>
+                      <Tooltip title={record.provider2 === "" ? i18next.t("record:Need provider" + " 2") : ""}>
+                        <Button
+                          disabled={record.provider2 === ""}
+                          type="primary" danger
+                          onClick={() => this.commitRecord(index, false)}
+                        >{i18next.t("record:Commit") + " 2"}
+                        </Button>
+                      </Tooltip>
                     ) : (
                       <Button
                         disabled={record.block2 === ""}
-                        style={{marginTop: "10px", marginRight: "10px"}}
                         type="primary"
                         onClick={() => this.queryRecord(record, false)}
                       >{i18next.t("record:Query") + " 2"}
@@ -418,7 +446,6 @@ class RecordListPage extends BaseListPage {
               }
               <Button
                 // disabled={record.owner !== this.props.account.owner}
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
                 onClick={() => this.props.history.push(`/records/${record.owner}/${record.name}`)}
               >{i18next.t("general:View")}
               </Button>
@@ -449,7 +476,12 @@ class RecordListPage extends BaseListPage {
         <Table scroll={{x: "max-content"}} columns={columns} dataSource={records} rowKey={(record) => `${record.owner}/${record.name}`} rowSelection={this.getRowSelection()} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
-              {i18next.t("general:Records")}&nbsp;&nbsp;&nbsp;&nbsp;
+              {i18next.t("general:Records")}
+              {Setting.isAdminUser(this.props.account) && (
+                <Button type={this.state.enableCrossChain ? "primary" : "default"} size="small" onClick={this.toggleEnableCrossChain} style={{marginLeft: 16}}>
+                  {this.state.enableCrossChain ? i18next.t("record:Disable cross-chain") : i18next.t("record:Enable cross-chain")}
+                </Button>
+              )}
               {this.state.selectedRowKeys.length > 0 && (
                 <Popconfirm title={`${i18next.t("general:Sure to delete")}: ${this.state.selectedRowKeys.length} ${i18next.t("general:items")} ?`} onConfirm={() => this.performBulkDelete(this.state.selectedRows, this.state.selectedRowKeys)} okText={i18next.t("general:OK")} cancelText={i18next.t("general:Cancel")}>
                   <Button type="primary" danger size="small" icon={<DeleteOutlined />} style={{marginLeft: 8}}>


### PR DESCRIPTION
Continue: https://github.com/casibase/casibase/issues/1387

Implements support for cross-chain functionality, optimizes the record editing page, and adds a blockchain provider selection feature.

### Cross-Chain Support
- Added a switch control for cross-chain functionality
- Supports dynamic enabling/disabling of cross-chain functionality on the list page
- Cross-chain status is persisted through localStorage
- Only administrators can see [Enable cross-chain] button

### Record Editing Page Optimization
- Changed the blockchain provider input box to a dropdown selection box
- Added a second blockchain provider selection field

### List Page Improvements
- Added a cross-chain functionality switch button (visible only to administrators)
- Optimized the layout of operation buttons using flex layout
- Added tooltips to remind users to configure providers

## Backend Improvements

### Record Management
- Optimized the `UpdateRecord` method to support resetting block information when switching providers
- Improved error handling for the `getRecordProvider` method
- Optimized the 'topparam' method to clean up old information


https://github.com/user-attachments/assets/6ccf7b52-61ba-4adb-b439-98df0d86f1c6


