### PR TITLE
fix: resolve Gemini API role configuration error

### DIFF
--- a/model/gemini_util.go
+++ b/model/gemini_util.go
@@ -17,7 +17,7 @@ package model
 import genai "google.golang.org/genai"
 
 func GenaiRawMessagesToMessages(question string, history []*RawMessage) []*genai.Content {
-	messages := make([]*genai.Content, 0, len(history)+1)
+	messages := []*genai.Content{}
 	for _, rawMessage := range history {
 		var role string
 		switch rawMessage.Author {

--- a/model/gemini_util.go
+++ b/model/gemini_util.go
@@ -19,11 +19,21 @@ import genai "google.golang.org/genai"
 func GenaiRawMessagesToMessages(question string, history []*RawMessage) []*genai.Content {
 	var messages []*genai.Content
 	for _, rawMessage := range history {
+		var role string
+		switch rawMessage.Author {
+		case "user", "System":
+			role = genai.RoleUser
+		case "AI", "assistant", "model":
+			role = genai.RoleModel
+		default:
+			role = genai.RoleUser
+		}
+
 		messages = append(messages, &genai.Content{
 			Parts: []*genai.Part{
 				{Text: rawMessage.Text},
 			},
-			Role: rawMessage.Author,
+			Role: role,
 		})
 	}
 	messages = append(messages, &genai.Content{

--- a/model/gemini_util.go
+++ b/model/gemini_util.go
@@ -17,7 +17,7 @@ package model
 import genai "google.golang.org/genai"
 
 func GenaiRawMessagesToMessages(question string, history []*RawMessage) []*genai.Content {
-	var messages []*genai.Content
+	messages := make([]*genai.Content, 0, len(history)+1)
 	for _, rawMessage := range history {
 		var role string
 		switch rawMessage.Author {


### PR DESCRIPTION
The Gemini API documentation states that the role can only be "user" or "model".

https://ai.google.dev/api/caching#Content

```
role: string
Optional. The producer of the content. Must be either 'user' or 'model'.
```

I also encountered this issue during usage:

![Snipaste_2025-10-17_21-25-49](https://github.com/user-attachments/assets/044cb75a-f6ea-49ae-8ae9-e92634ffbeec)

Mapping rawMessage.Author to either "user" or "model" solved the problem.