### PR TITLE
feat: implement add-edit-cancel flow for all resources

### DIFF
--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -36,6 +36,7 @@ class ApplicationEditPage extends React.Component {
       application: null,
       templates: [],
       deploying: false,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -151,6 +152,7 @@ class ApplicationEditPage extends React.Component {
           {i18next.t("application:Edit Application")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitApplicationEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitApplicationEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteApplication()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={(Setting.isMobile()) ? {margin: "5px"} : {}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -318,6 +320,20 @@ class ApplicationEditPage extends React.Component {
       });
   }
 
+  deleteApplication() {
+    ApplicationBackend.deleteApplication(this.state.application)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/applications");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -327,6 +343,7 @@ class ApplicationEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitApplicationEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitApplicationEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteApplication()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/ApplicationListPage.js
+++ b/web/src/ApplicationListPage.js
@@ -173,13 +173,8 @@ class ApplicationListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newApplication),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/applications/${newApplication.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
@@ -406,7 +401,7 @@ class ApplicationListPage extends BaseListPage {
                   </Button>
                 </Popconfirm>
               )}
-                       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               {i18next.t("general:Status")}:
               &nbsp;
               {this.state.k8sStatus === "Connected" ? Setting.getDisplayTag(i18next.t("general:Active"), "green") : Setting.getDisplayTag(i18next.t("general:Inactive"), "red")}

--- a/web/src/ApplicationStorePage.js
+++ b/web/src/ApplicationStorePage.js
@@ -117,7 +117,7 @@ class ApplicationStorePage extends React.Component {
       .then((res) => {
         if (res.status === "ok") {
           message.success(i18next.t("general:Successfully added"));
-          this.props.history.push(`/applications/${newApplication.name}`);
+          this.props.history.push(`/applications/${newApplication.name}`, {mode: "add"});
         } else {
           message.error(`${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/ArticleEditPage.js
+++ b/web/src/ArticleEditPage.js
@@ -34,6 +34,7 @@ class ArticleEditPage extends React.Component {
       article: null,
       chatPageObj: null,
       loading: false,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
 
     this.articleTableRef = React.createRef();
@@ -337,6 +338,7 @@ class ArticleEditPage extends React.Component {
           {i18next.t("article:Edit Article")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitArticleEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitArticleEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteArticle()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -453,6 +455,20 @@ class ArticleEditPage extends React.Component {
       });
   }
 
+  deleteArticle() {
+    ArticleBackend.deleteArticle(this.state.article)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/articles");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -462,6 +478,7 @@ class ArticleEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitArticleEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitArticleEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteArticle()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/ArticleListPage.js
+++ b/web/src/ArticleListPage.js
@@ -47,13 +47,8 @@ class ArticleListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newArticle),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/articles/${newArticle.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/AssetEditPage.js
+++ b/web/src/AssetEditPage.js
@@ -32,7 +32,7 @@ class AssetEditPage extends React.Component {
       providers: [],
       scans: [],
       loadingScans: false,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/AssetListPage.js
+++ b/web/src/AssetListPage.js
@@ -91,7 +91,7 @@ class AssetListPage extends BaseListPage {
     AssetBackend.addAsset(newAsset)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/assets/${newAsset.name}`, mode: "add"});
+          this.props.history.push(`/assets/${newAsset.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/CaaseEditPage.js
+++ b/web/src/CaaseEditPage.js
@@ -31,7 +31,7 @@ class CaaseEditPage extends React.Component {
       patients: [],
       doctors: [],
       hospitals: [],
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/CaaseListPage.js
+++ b/web/src/CaaseListPage.js
@@ -53,10 +53,7 @@ class CaaseListPage extends BaseListPage {
     CaaseBackend.addCaase(newCaase)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({
-            pathname: `/caases/${newCaase.name}`,
-            mode: "add",
-          });
+          this.props.history.push(`/caases/${newCaase.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/ChatEditPage.js
+++ b/web/src/ChatEditPage.js
@@ -34,6 +34,7 @@ class ChatEditPage extends React.Component {
       messages: null,
       provider: null,
       providers: [],
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
       // users: [],
     };
   }
@@ -120,6 +121,7 @@ class ChatEditPage extends React.Component {
           {i18next.t("chat:Edit Chat")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitChatEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitChatEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteChat()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={(Setting.isMobile()) ? {margin: "5px"} : {}} type="inner">
         {/* <Row style={{marginTop: "10px"}} >*/}
@@ -313,6 +315,20 @@ class ChatEditPage extends React.Component {
       });
   }
 
+  deleteChat() {
+    ChatBackend.deleteChat(this.state.chat)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/chats");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -322,6 +338,7 @@ class ChatEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitChatEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitChatEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteChat()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/ChatListPage.js
+++ b/web/src/ChatListPage.js
@@ -121,13 +121,7 @@ class ChatListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newChat),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          this.props.history.push(`/chats/${newChat.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/ConsultationEditPage.js
+++ b/web/src/ConsultationEditPage.js
@@ -33,7 +33,7 @@ class ConsultationEditPage extends React.Component {
       patients: [],
       doctors: [],
       hospitals: [],
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/ConsultationListPage.js
+++ b/web/src/ConsultationListPage.js
@@ -45,7 +45,7 @@ class ConsultationListPage extends BaseListPage {
     ConsultationBackend.addConsultation(newConsultation)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/consultations/${newConsultation.name}`, mode: "add"});
+          this.props.history.push(`/consultations/${newConsultation.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/ContainerEditPage.js
+++ b/web/src/ContainerEditPage.js
@@ -28,7 +28,7 @@ class ContainerEditPage extends React.Component {
       containerOwner: props.match.params.organizationName,
       containerName: props.match.params.containerName,
       container: null,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/ContainerListPage.js
+++ b/web/src/ContainerListPage.js
@@ -51,7 +51,7 @@ class ContainerListPage extends BaseListPage {
     ContainerBackend.addContainer(newContainer)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/containers/${newContainer.owner}/${newContainer.name}`, mode: "add"});
+          this.props.history.push(`/containers/${newContainer.owner}/${newContainer.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/DoctorEditPage.js
+++ b/web/src/DoctorEditPage.js
@@ -28,7 +28,7 @@ class DoctorEditPage extends React.Component {
       doctorName: props.match.params.doctorName,
       doctor: null,
       hospitals: [],
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -232,7 +232,7 @@ class DoctorEditPage extends React.Component {
             } else {
               this.props.history.push(`/doctors/${encodeURIComponent(this.state.doctor.name)}`);
             }
-          // this.getDoctor(true);
+            // this.getDoctor(true);
           } else {
             Setting.showMessage("error", i18next.t("general:Failed to save"));
             this.updateDoctorField("name", this.state.doctorName);

--- a/web/src/DoctorListPage.js
+++ b/web/src/DoctorListPage.js
@@ -46,10 +46,7 @@ class DoctorListPage extends BaseListPage {
     DoctorBackend.addDoctor(newDoctor)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({
-            pathname: `/doctors/${newDoctor.name}`,
-            mode: "add",
-          });
+          this.props.history.push(`/doctors/${newDoctor.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/FileEditPage.js
+++ b/web/src/FileEditPage.js
@@ -27,6 +27,7 @@ class FileEditPage extends React.Component {
       classes: props,
       fileName: props.match.params.fileName,
       file: null,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -71,6 +72,7 @@ class FileEditPage extends React.Component {
           {i18next.t("file:Edit File")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitFileEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitFileEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteFile()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -201,6 +203,20 @@ class FileEditPage extends React.Component {
       });
   }
 
+  deleteFile() {
+    FileBackend.deleteFile(this.state.file)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/files");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -210,6 +226,7 @@ class FileEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitFileEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitFileEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteFile()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/FileListPage.js
+++ b/web/src/FileListPage.js
@@ -51,13 +51,7 @@ class FileListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newFile),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          this.props.history.push(`/files/${newFile.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/FormEditPage.js
+++ b/web/src/FormEditPage.js
@@ -39,6 +39,7 @@ class FormEditPage extends React.Component {
       formName: props.match.params.formName,
       form: null,
       formCount: "key",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -83,6 +84,7 @@ class FormEditPage extends React.Component {
           {i18next.t("form:Edit Form")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitFormEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitFormEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteForm()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -303,6 +305,20 @@ class FormEditPage extends React.Component {
       });
   }
 
+  deleteForm() {
+    FormBackend.deleteForm(this.state.form)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/forms");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -312,6 +328,7 @@ class FormEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitFormEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitFormEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteForm()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/FormListPage.js
+++ b/web/src/FormListPage.js
@@ -49,13 +49,8 @@ class FormListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newForm),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/forms/${newForm.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/GraphEditPage.js
+++ b/web/src/GraphEditPage.js
@@ -42,6 +42,7 @@ class GraphEditPage extends React.Component {
       filteredChats: [],
       tempStartTime: null,
       tempEndTime: null,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -149,6 +150,7 @@ class GraphEditPage extends React.Component {
           {i18next.t("graph:Edit Graph")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitGraphEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitGraphEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteGraph()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -391,6 +393,20 @@ class GraphEditPage extends React.Component {
       });
   }
 
+  deleteGraph() {
+    GraphBackend.deleteGraph(this.state.graph)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/graphs");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -403,6 +419,7 @@ class GraphEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitGraphEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitGraphEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteGraph()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/GraphListPage.js
+++ b/web/src/GraphListPage.js
@@ -49,13 +49,8 @@ class GraphListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newGraph),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/graphs/${newGraph.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/HospitalEditPage.js
+++ b/web/src/HospitalEditPage.js
@@ -27,7 +27,7 @@ class HospitalEditPage extends React.Component {
 
       hospitalName: props.match.params.hospitalName,
       hospital: null,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/HospitalListPage.js
+++ b/web/src/HospitalListPage.js
@@ -43,7 +43,7 @@ class HospitalListPage extends BaseListPage {
     HospitalBackend.addHospital(newHospital)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/hospitals/${newHospital.name}`, mode: "add"});
+          this.props.history.push(`/hospitals/${newHospital.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/ImageEditPage.js
+++ b/web/src/ImageEditPage.js
@@ -26,7 +26,7 @@ class ImageEditPage extends React.Component {
       imageOwner: props.match.params.organizationName,
       imageName: props.match.params.imageName,
       image: null,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/ImageListPage.js
+++ b/web/src/ImageListPage.js
@@ -54,7 +54,7 @@ class ImageListPage extends BaseListPage {
     ImageBackend.addImage(newImage)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/images/${newImage.owner}/${newImage.name}`, mode: "add"});
+          this.props.history.push(`/images/${newImage.owner}/${newImage.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
@@ -113,7 +113,7 @@ class ImageListPage extends BaseListPage {
     MachineBackend.addMachine(newMachine)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/machines/${newMachine.owner}/${newMachine.name}`, mode: "add"});
+          this.props.history.push(`/machines/${newMachine.owner}/${newMachine.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/MachineEditPage.js
+++ b/web/src/MachineEditPage.js
@@ -28,7 +28,7 @@ class MachineEditPage extends React.Component {
       machineOwner: props.match.params.organizationName,
       machineName: props.match.params.machineName,
       machine: null,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/MachineListPage.js
+++ b/web/src/MachineListPage.js
@@ -56,7 +56,7 @@ class MachineListPage extends BaseListPage {
     MachineBackend.addMachine(newMachine)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/machines/${newMachine.owner}/${newMachine.name}`, mode: "add"});
+          this.props.history.push(`/machines/${newMachine.owner}/${newMachine.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/MessageEditPage.js
+++ b/web/src/MessageEditPage.js
@@ -36,6 +36,7 @@ class MessageEditPage extends React.Component {
       chat: null,
       provider: null,
       providers: [],
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -148,6 +149,7 @@ class MessageEditPage extends React.Component {
           {i18next.t("message:Edit Message")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitMessageEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitMessageEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteMessage()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={(Setting.isMobile()) ? {margin: "5px"} : {}} type="inner">
         {/* <Row style={{marginTop: "10px"}} >*/}
@@ -386,6 +388,20 @@ class MessageEditPage extends React.Component {
       });
   }
 
+  deleteMessage() {
+    MessageBackend.deleteMessage(this.state.message)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/messages");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -393,6 +409,7 @@ class MessageEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitMessageEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitMessageEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteMessage()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -82,13 +82,7 @@ class MessageListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newMessage),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          this.props.history.push(`/messages/${newMessage.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/NodeEditPage.js
+++ b/web/src/NodeEditPage.js
@@ -31,7 +31,7 @@ class NodeEditPage extends React.Component {
       nodeName: props.match.params.nodeName,
       node: null,
       organizations: [],
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
 
     this.timer = null;

--- a/web/src/NodeListPage.js
+++ b/web/src/NodeListPage.js
@@ -56,7 +56,7 @@ class NodeListPage extends BaseListPage {
     NodeBackend.addNode(newNode)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/nodes/${newNode.name}`, mode: "add"});
+          this.props.history.push(`/nodes/${newNode.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/OsDesktop.js
+++ b/web/src/OsDesktop.js
@@ -79,11 +79,11 @@ const WindowContent = ({appType, account, history, match, location, isDesktopMod
 const Window = ({title, isMaximized, onClose, onMaximize, onMinimize, onFocus, appType, appConfig, account, history, match, location, onRouteChange, windowHistory, onGoBack, onGoForward}) => {
   const windowHistoryObj = {
     ...history,
-    push: (path) => {
-      onRouteChange(path);
+    push: (path, state) => {
+      onRouteChange(path, state);
     },
-    replace: (path) => {
-      onRouteChange(path);
+    replace: (path, state) => {
+      onRouteChange(path, state);
     },
     goBack: () => onGoBack(),
     goForward: () => onGoForward(),
@@ -96,8 +96,8 @@ const Window = ({title, isMaximized, onClose, onMaximize, onMinimize, onFocus, a
     createHref: (location) => {
       return typeof location === "string" ? location : location.pathname;
     },
-    block: () => () => {},
-    listen: () => () => {},
+    block: () => () => { },
+    listen: () => () => { },
   };
 
   const canGoBack = windowHistory && windowHistory.currentIndex > 0;
@@ -531,7 +531,7 @@ const OsDesktop = (props) => {
     return {};
   };
 
-  const updateWindowRoute = (id, newRoute) => {
+  const updateWindowRoute = (id, newRoute, newState = null) => {
     const currentWindow = windows.find(window => window.id === id);
 
     const newHistory = {
@@ -552,7 +552,7 @@ const OsDesktop = (props) => {
       pathname: newRoute,
       search: "",
       hash: "",
-      state: null,
+      state: newState,
     };
 
     setWindows(prevWindows => prevWindows.map(window =>
@@ -819,7 +819,7 @@ const OsDesktop = (props) => {
                   onMaximize={() => toggleMaximize(window.id)}
                   onMinimize={() => minimizeWindow(window.id)}
                   onFocus={() => focusWindow(window.id)}
-                  onRouteChange={(newRoute) => updateWindowRoute(window.id, newRoute)}
+                  onRouteChange={(newRoute, newState) => updateWindowRoute(window.id, newRoute, newState)}
                   onGoBack={() => goBack(window.id)}
                   onGoForward={() => goForward(window.id)}
                 />

--- a/web/src/PatientEditPage.js
+++ b/web/src/PatientEditPage.js
@@ -30,7 +30,7 @@ class PatientEditPage extends React.Component {
       patient: null,
       doctors: [],
       hospitals: [],
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/PatientListPage.js
+++ b/web/src/PatientListPage.js
@@ -48,7 +48,7 @@ class PatientListPage extends BaseListPage {
     PatientBackend.addPatient(newPatient)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/patients/${newPatient.name}`, mode: "add"});
+          this.props.history.push(`/patients/${newPatient.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/PodEditPage.js
+++ b/web/src/PodEditPage.js
@@ -28,7 +28,7 @@ class PodEditPage extends React.Component {
       podOwner: props.match.params.organizationName,
       podName: props.match.params.podName,
       pod: null,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/PodListPage.js
+++ b/web/src/PodListPage.js
@@ -47,7 +47,7 @@ class PodListPage extends BaseListPage {
     PodBackend.addPod(newPod)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/pods/${newPod.owner}/${newPod.name}`, mode: "add"});
+          this.props.history.push(`/pods/${newPod.owner}/${newPod.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -44,6 +44,7 @@ class ProviderEditPage extends React.Component {
       originalProvider: null,
       refreshButtonLoading: false,
       isAdmin: props.account?.isAdmin || props.account?.owner === "admin",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -267,6 +268,7 @@ class ProviderEditPage extends React.Component {
           {isRemote ? i18next.t("general:View") : i18next.t("provider:Edit Provider")}&nbsp;&nbsp;&nbsp;&nbsp;
           {!isRemote && <Button onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>}
           {!isRemote && <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>}
+          {!isRemote && this.state.mode === "add" && <Button style={{marginLeft: "20px"}} onClick={() => this.deleteProvider()}>{i18next.t("general:Cancel")}</Button>}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -450,7 +452,7 @@ class ProviderEditPage extends React.Component {
             >
               {
                 Setting.getProviderTypeOptions(this.state.provider.category)
-                // .sort((a, b) => a.name.localeCompare(b.name))
+                  // .sort((a, b) => a.name.localeCompare(b.name))
                   .map((item, index) => <Option key={index} value={item.name}>
                     <img width={20} height={20} style={{marginBottom: "3px", marginRight: "10px"}} src={Setting.getProviderLogoURL({category: this.state.provider.category, type: item.name})} alt={item.name} />
                     {item.name}
@@ -521,16 +523,16 @@ class ProviderEditPage extends React.Component {
         }
         {
           !(this.state.provider.category === "Private Cloud" && this.state.provider.type === "Kubernetes") &&
-          this.state.provider.category !== "Scan" &&
-          (
-            ((this.state.provider.category === "Embedding" && this.state.provider.type === "Baidu Cloud") ||
-              (this.state.provider.category === "Embedding" && this.state.provider.type === "Tencent Cloud") ||
-              (this.state.provider.category === "Storage" && this.state.provider.type !== "OpenAI File System")) ||
-            (this.state.provider.category === "Model" && this.state.provider.type === "MiniMax") ||
-            (this.state.provider.category === "Blockchain" && !["ChainMaker", "Ethereum"].includes(this.state.provider.type)) ||
-            ((this.state.provider.category === "Model" || this.state.provider.category === "Embedding") && this.state.provider.type === "Azure") ||
-            (!(["Storage", "Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Agent", "Blockchain"].includes(this.state.provider.category)))
-          ) ? (
+            this.state.provider.category !== "Scan" &&
+            (
+              ((this.state.provider.category === "Embedding" && this.state.provider.type === "Baidu Cloud") ||
+                (this.state.provider.category === "Embedding" && this.state.provider.type === "Tencent Cloud") ||
+                (this.state.provider.category === "Storage" && this.state.provider.type !== "OpenAI File System")) ||
+              (this.state.provider.category === "Model" && this.state.provider.type === "MiniMax") ||
+              (this.state.provider.category === "Blockchain" && !["ChainMaker", "Ethereum"].includes(this.state.provider.type)) ||
+              ((this.state.provider.category === "Model" || this.state.provider.category === "Embedding") && this.state.provider.type === "Azure") ||
+              (!(["Storage", "Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Agent", "Blockchain"].includes(this.state.provider.category)))
+            ) ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
                   {this.getClientIdLabel(this.state.provider)} :
@@ -556,7 +558,7 @@ class ProviderEditPage extends React.Component {
                   })}>
                     {
                       Setting.getCompatibleProviderOptions(this.state.provider.category)
-                      // .sort((a, b) => a.name.localeCompare(b.name))
+                        // .sort((a, b) => a.name.localeCompare(b.name))
                         .map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
                     }
                   </Select>
@@ -1278,6 +1280,20 @@ class ProviderEditPage extends React.Component {
       });
   }
 
+  deleteProvider() {
+    ProviderBackend.deleteProvider(this.state.provider)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/providers");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     const isRemote = this.state.provider?.isRemote;
     return (
@@ -1289,6 +1305,7 @@ class ProviderEditPage extends React.Component {
           <div style={{marginTop: "20px", marginLeft: "40px"}}>
             <Button size="large" onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+            {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteProvider()}>{i18next.t("general:Cancel")}</Button> : null}
           </div>
         )}
       </div>

--- a/web/src/ProviderListPage.js
+++ b/web/src/ProviderListPage.js
@@ -89,13 +89,8 @@ class ProviderListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newProvider),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // Navigate to edit page with mode parameter
+          this.props.history.push(`/providers/${newProvider.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/RecordEditPage.js
+++ b/web/src/RecordEditPage.js
@@ -35,7 +35,7 @@ class RecordEditPage extends React.Component {
       recordName: props.match.params.recordName,
       record: null,
       blockchainProviders: [],
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -116,7 +116,7 @@ class RecordListPage extends BaseListPage {
     RecordBackend.addRecord(newRecord)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/records/${newRecord.owner}/${newRecord.id}`, mode: "add"});
+          this.props.history.push(`/records/${newRecord.owner}/${newRecord.id}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/ScanEditPage.js
+++ b/web/src/ScanEditPage.js
@@ -26,7 +26,7 @@ class ScanEditPage extends React.Component {
       classes: props,
       scanName: props.match.params.scanName,
       scan: null,
-      mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 

--- a/web/src/ScanListPage.js
+++ b/web/src/ScanListPage.js
@@ -142,7 +142,7 @@ class ScanListPage extends BaseListPage {
     ScanBackend.addScan(newScan)
       .then((res) => {
         if (res.status === "ok") {
-          this.props.history.push({pathname: `/scans/${newScan.name}`, mode: "add"});
+          this.props.history.push(`/scans/${newScan.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);

--- a/web/src/StoreEditPage.js
+++ b/web/src/StoreEditPage.js
@@ -51,6 +51,7 @@ class StoreEditPage extends React.Component {
       enableTtsStreaming: false,
       store: null,
       themeColor: ThemeDefault.colorPrimary,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -207,6 +208,7 @@ class StoreEditPage extends React.Component {
           {i18next.t("store:Edit Store")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitStoreEdit(false, undefined)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitStoreEdit(true, undefined)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteStore()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -788,6 +790,21 @@ class StoreEditPage extends React.Component {
       });
   }
 
+  deleteStore() {
+    StoreBackend.deleteStore(this.state.store)
+      .then((res) => {
+        if (res.status === "ok") {
+          window.dispatchEvent(new Event("storesChanged"));
+          this.props.history.push("/stores");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -797,6 +814,7 @@ class StoreEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitStoreEdit(false, undefined)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitStoreEdit(true, undefined)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteStore()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/StoreListPage.js
+++ b/web/src/StoreListPage.js
@@ -128,7 +128,7 @@ class StoreListPage extends BaseListPage {
   newStore() {
     const randomName = Setting.getRandomName();
     return {
-      owner: "admin",
+      owner: this.props.account.name,
       name: `store_${randomName}`,
       displayName: `New Store - ${randomName}`,
       createdTime: moment().format(),
@@ -169,15 +169,10 @@ class StoreListPage extends BaseListPage {
     StoreBackend.addStore(newStore)
       .then((res) => {
         if (res.status === "ok") {
+          // Navigate to edit page with mode parameter
+          this.props.history.push(`/stores/${newStore.owner}/${newStore.name}`, {mode: "add"});
           Setting.showMessage("success", i18next.t("general:Successfully added"));
           window.dispatchEvent(new Event("storesChanged"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newStore),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
@@ -450,7 +445,7 @@ class StoreListPage extends BaseListPage {
           return (
             <div>
               <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} onClick={() => this.props.history.push(`/stores/${record.owner}/${record.name}/view`)}>{i18next.t("general:View")}</Button>
-              <Button style={{marginBottom: "10px", marginRight: "10px"}} icon={<CopyOutlined />} onClick={() => {copy(`${window.location.origin}/${record.owner}/${record.name}/chat`);Setting.showMessage("success", i18next.t("general:Successfully copied"));}}>{i18next.t("general:Copy Link")}</Button>
+              <Button style={{marginBottom: "10px", marginRight: "10px"}} icon={<CopyOutlined />} onClick={() => {copy(`${window.location.origin}/${record.owner}/${record.name}/chat`); Setting.showMessage("success", i18next.t("general:Successfully copied"));}}>{i18next.t("general:Copy Link")}</Button>
               <Button style={{marginBottom: "10px", marginRight: "10px"}} onClick={() => {
                 Setting.setStore(record.name);
                 window.open(`${window.location.origin}/${record.owner}/${record.name}/chat`, "_blank");

--- a/web/src/TaskEditPage.js
+++ b/web/src/TaskEditPage.js
@@ -40,6 +40,7 @@ class TaskEditPage extends React.Component {
       task: null,
       chatPageObj: null,
       loading: false,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -134,6 +135,7 @@ class TaskEditPage extends React.Component {
           {i18next.t("task:Edit Task")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitTaskEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitTaskEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteTask()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -337,7 +339,7 @@ class TaskEditPage extends React.Component {
             {Setting.getLabel(i18next.t("task:Question"), i18next.t("task:Question - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <TextArea disabled={true} autoSize={{minRows: 1, maxRows: 15}} value={(this.state.task.type !== "Labeling") ? this.getProjectText() : this.getQuestion()} onChange={(e) => {}} />
+            <TextArea disabled={true} autoSize={{minRows: 1, maxRows: 15}} value={(this.state.task.type !== "Labeling") ? this.getProjectText() : this.getQuestion()} onChange={(e) => { }} />
           </Col>
         </Row>
         {
@@ -426,6 +428,20 @@ class TaskEditPage extends React.Component {
       });
   }
 
+  deleteTask() {
+    TaskBackend.deleteTask(this.state.task)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/tasks");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -435,6 +451,7 @@ class TaskEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitTaskEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitTaskEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteTask()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/TaskListPage.js
+++ b/web/src/TaskListPage.js
@@ -51,13 +51,8 @@ class TaskListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newTask),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/tasks/${newTask.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/TemplateEditPage.js
+++ b/web/src/TemplateEditPage.js
@@ -35,6 +35,7 @@ class TemplateEditPage extends React.Component {
       templateName: props.match.params.templateName,
       template: null,
       defaultStore: null,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -96,6 +97,7 @@ class TemplateEditPage extends React.Component {
           {i18next.t("template:Edit Template")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitTemplateEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitTemplateEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteTemplate()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -240,6 +242,20 @@ class TemplateEditPage extends React.Component {
       });
   }
 
+  deleteTemplate() {
+    TemplateBackend.deleteTemplate(this.state.template)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/templates");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -249,6 +265,7 @@ class TemplateEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitTemplateEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitTemplateEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteTemplate()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/TemplateListPage.js
+++ b/web/src/TemplateListPage.js
@@ -67,13 +67,8 @@ spec:
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newTemplate),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/templates/${newTemplate.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }

--- a/web/src/VectorEditPage.js
+++ b/web/src/VectorEditPage.js
@@ -32,6 +32,7 @@ class VectorEditPage extends React.Component {
       classes: props,
       vectorName: props.match.params.vectorName,
       vector: null,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location.mode !== undefined ? props.location.mode : "edit"),
     };
   }
 
@@ -80,6 +81,7 @@ class VectorEditPage extends React.Component {
           {i18next.t("vector:Edit Vector")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitVectorEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitVectorEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteVector()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -209,6 +211,20 @@ class VectorEditPage extends React.Component {
       });
   }
 
+  deleteVector() {
+    VectorBackend.deleteVector(this.state.vector)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/vectors");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -218,6 +234,7 @@ class VectorEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitVectorEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitVectorEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteVector()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/VectorListPage.js
+++ b/web/src/VectorListPage.js
@@ -50,13 +50,8 @@ class VectorListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newVector),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // Navigate to edit page with mode parameter
+          this.props.history.push(`/vectors/${newVector.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
@@ -192,7 +187,7 @@ class VectorListPage extends BaseListPage {
         render: (text, record, index) => {
           return (
             <Popover placement="left" content={
-              <TextArea style={{width: "800px", backgroundColor: "black", color: "white"}} autoSize={{minRows: 1, maxRows: 100}} value={text} onChange={e => {}} />
+              <TextArea style={{width: "800px", backgroundColor: "black", color: "white"}} autoSize={{minRows: 1, maxRows: 100}} value={text} onChange={e => { }} />
             } title="" trigger="hover">
               <div style={{maxWidth: "200px"}}>
                 {Setting.getShortText(text, 60)}

--- a/web/src/WorkflowEditPage.js
+++ b/web/src/WorkflowEditPage.js
@@ -35,6 +35,7 @@ class WorkflowEditPage extends React.Component {
       workflow: null,
       chatPageObj: null,
       loading: false,
+      mode: props.location?.state?.mode !== undefined ? props.location.state.mode : (props.location?.mode !== undefined ? props.location.mode : "edit"),
     };
 
     this.questionTemplatesOptions = [
@@ -105,6 +106,7 @@ class WorkflowEditPage extends React.Component {
           {i18next.t("workflow:Edit Workflow")}&nbsp;&nbsp;&nbsp;&nbsp;
           <Button onClick={() => this.submitWorkflowEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitWorkflowEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteWorkflow()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={{marginLeft: "5px"}} type="inner">
         <Row style={{marginTop: "10px"}} >
@@ -300,6 +302,20 @@ class WorkflowEditPage extends React.Component {
       });
   }
 
+  deleteWorkflow() {
+    WorkflowBackend.deleteWorkflow(this.state.workflow)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/workflows");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
+      });
+  }
+
   render() {
     return (
       <div>
@@ -309,6 +325,7 @@ class WorkflowEditPage extends React.Component {
         <div style={{marginTop: "20px", marginLeft: "40px"}}>
           <Button size="large" onClick={() => this.submitWorkflowEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitWorkflowEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+          {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteWorkflow()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       </div>
     );

--- a/web/src/WorkflowListPage.js
+++ b/web/src/WorkflowListPage.js
@@ -70,13 +70,8 @@ class WorkflowListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully added"));
-          this.setState({
-            data: Setting.prependRow(this.state.data, newWorkflow),
-            pagination: {
-              ...this.state.pagination,
-              total: this.state.pagination.total + 1,
-            },
-          });
+          // 跳转到编辑页，带 mode 参数
+          this.props.history.push(`/workflows/${newWorkflow.name}`, {mode: "add"});
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
@@ -202,7 +197,7 @@ class WorkflowListPage extends BaseListPage {
         render: (text, record, index) => {
           return (
             <Tooltip placement="left" styles={{body: {width: "815px", maxHeight: "355px"}}} title={
-              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={text} onChange={(e) => {}} />
+              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={text} onChange={(e) => { }} />
             }>
               <div style={{maxWidth: "300px"}}>
                 {Setting.getShortText(text, 100)}

--- a/web/src/component/AppRouteManager.js
+++ b/web/src/component/AppRouteManager.js
@@ -521,17 +521,30 @@ export const DynamicRouteComponent = ({appType, match, location, ...props}) => {
   useEffect(() => {
     const componentLoader = routeManager.getRouteComponent(appType, location.pathname);
 
-    componentLoader()
-      .then(module => {
-        setComponent(() => module.default);
-        setLoading(false);
-      });
+    if (componentLoader && typeof componentLoader === "function") {
+      componentLoader()
+        .then(module => {
+          setComponent(() => module.default);
+          setLoading(false);
+        });
+    } else {
+      setLoading(false);
+    }
   }, [appType, location.pathname]);
 
   if (loading) {
     return (
       <div style={{padding: "20px", textAlign: "center"}}>
         <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!Component) {
+    return (
+      <div style={{padding: "20px", textAlign: "center"}}>
+        <h2>Page not found</h2>
+        <p>The requested page does not exist.</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Implement a consistent "Add → Edit → Save/Cancel" flow across all resource management pages in casibase, improving user experience by eliminating the need for an extra "Edit" click after creating a new record.

## Current behavior

1. Go to any list page (e.g., `Providers`, `Stores`, `Vectors`).
2. Click the **Add** button.
3. The system automatically creates a new record with default values.
4. The page stays on or returns to the list page.
5. The user needs to click **Edit** on that record to configure it.

**Problem**: This flow requires extra clicks and may create incomplete records with default values that the user didn't intend.

## Expected behavior

1. Go to any list page (e.g., `Providers`, `Stores`, `Vectors`).
2. Click the **Add** button.
3. **Directly open the edit page for the new record** (NEW).
4. After the user fills in the information and clicks **Save**, the new record appears in the list.
5. If the user clicks **Cancel**, the record is deleted and returns to the list.

**Benefit**: This is consistent with the standard "Add → Edit → Save" pattern and provides better user experience.

## Implementation details

### Mode tracking
- Added `mode` state to EditPage constructors to distinguish between "add" and "edit" modes
- Mode is passed via `location.state.mode` when navigating from ListPage
- Supports backward compatibility with direct URL access

### UI changes
- Added **Cancel button** to EditPage:
  - Upper Cancel button in Card title (conditionally shown when `mode === 'add'`)
  - Lower Cancel button in render method (conditionally shown when `mode === 'add'`)
  - Hidden when in edit mode for existing records

### Navigation flow
- ListPage `addXXX()` methods now navigate to EditPage with `{mode: 'add'}` state:
  ```javascript
  this.props.history.push(`/resources/${id}`, {mode: "add"});