### PR TITLE
feat: update model list in moonshot

### DIFF
--- a/model/moonshot.go
+++ b/model/moonshot.go
@@ -43,7 +43,7 @@ func NewMoonshotModelProvider(subType string, secretKey string, temperature floa
 
 func (p *MoonshotModelProvider) GetPricing() string {
 	return `URL: 
-	https://platform.moonshot.cn/docs/pricing/chat
+https://platform.moonshot.cn/docs/pricing/chat
 
 Model
 

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1632,9 +1632,15 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "Moonshot") {
     return [
-      {id: "moonshot-v1-8k", name: "moonshot-v1-8k"},
-      {id: "moonshot-v1-32k", name: "moonshot-v1-32k"},
-      {id: "moonshot-v1-128k", name: "moonshot-v1-128k"},
+      { id: "moonshot-v1-8k", name: "moonshot-v1-8k" },
+      { id: "moonshot-v1-32k", name: "moonshot-v1-32k" },
+      { id: "moonshot-v1-128k", name: "moonshot-v1-128k" },
+      { id: "kimi-k2-0905-preview", name: "kimi-k2-0905-preview" },
+      { id: "kimi-k2-0711-preview", name: "kimi-k2-0711-preview" },
+      { id: "kimi-k2-turbo-preview", name: "kimi-k2-turbo-preview" },
+      { id: "kimi-k2-thinking", name: "kimi-k2-thinking" },
+      { id: "kimi-k2-thinking-turbo", name: "kimi-k2-thinking-turbo" },
+      { id: "kimi-latest", name: "kimi-latest (Auto Tier)" },
     ];
   } else if (type === "Amazon Bedrock") {
     return [

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1632,15 +1632,15 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "Moonshot") {
     return [
-      { id: "moonshot-v1-8k", name: "moonshot-v1-8k" },
-      { id: "moonshot-v1-32k", name: "moonshot-v1-32k" },
-      { id: "moonshot-v1-128k", name: "moonshot-v1-128k" },
-      { id: "kimi-k2-0905-preview", name: "kimi-k2-0905-preview" },
-      { id: "kimi-k2-0711-preview", name: "kimi-k2-0711-preview" },
-      { id: "kimi-k2-turbo-preview", name: "kimi-k2-turbo-preview" },
-      { id: "kimi-k2-thinking", name: "kimi-k2-thinking" },
-      { id: "kimi-k2-thinking-turbo", name: "kimi-k2-thinking-turbo" },
-      { id: "kimi-latest", name: "kimi-latest (Auto Tier)" },
+      {id: "moonshot-v1-8k", name: "moonshot-v1-8k"},
+      {id: "moonshot-v1-32k", name: "moonshot-v1-32k"},
+      {id: "moonshot-v1-128k", name: "moonshot-v1-128k"},
+      {id: "kimi-k2-0905-preview", name: "kimi-k2-0905-preview"},
+      {id: "kimi-k2-0711-preview", name: "kimi-k2-0711-preview"},
+      {id: "kimi-k2-turbo-preview", name: "kimi-k2-turbo-preview"},
+      {id: "kimi-k2-thinking", name: "kimi-k2-thinking"},
+      {id: "kimi-k2-thinking-turbo", name: "kimi-k2-thinking-turbo"},
+      {id: "kimi-latest", name: "kimi-latest (Auto Tier)"},
     ];
   } else if (type === "Amazon Bedrock") {
     return [


### PR DESCRIPTION
This PR adds the following Kimi-v2 model subtypes
- `kimi-k2-0905-preview`
- `kimi-k2-0711-preview`
- `kimi-k2-turbo-preview`
- `kimi-k2-thinking`
- `kimi-k2-thinking-turbo`
- `kimi-latest (Auto Tier)`

### Backend
Added pricing logic for the new Kimi-v2 model subtypes in model/moonshot.go.

### Frontend
Added Kimi-v2 model subtypes to the frontend dropdown list.
