### PR TITLE
fix: fallback to defaultLogoUrl when logoUrl is empty in getLogo()

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -2350,6 +2350,9 @@ export function getLogo(themes, storeLogoUrl) {
   if (storeLogoUrl && storeLogoUrl !== defaultLogoUrl) {
     logoUrl = storeLogoUrl;
   }
+  if (!logoUrl) {
+    logoUrl = defaultLogoUrl;
+  }
   logoUrl = logoUrl.replace("https://cdn.casibase.org", Conf.StaticBaseUrl);
   if (themes.includes("dark")) {
     return logoUrl.replace(/\.png$/, "_white.png");


### PR DESCRIPTION
## Problem
When both `Conf.LogoUrl` and `storeLogoUrl` are empty strings, the `getLogo()` function in `Setting.js` returns an empty string instead of the default logo URL, causing the header logo to not display (shows a broken image icon).

## Root Cause
In `getLogo()`, the fallback to `defaultLogoUrl` only happens when `storeLogoUrl` is different from `defaultLogoUrl`. If `storeLogoUrl` is empty AND `Conf.LogoUrl` is also empty (which is the initial value), `logoUrl` remains empty and no fallback occurs.

## Fix
Added a check: if `logoUrl` is still empty after the store URL check, fall back to `defaultLogoUrl`.
