### PR TITLE
feat: submit OpenAgent records to AIGuard

### DIFF
--- a/aiguard/aiguard.go
+++ b/aiguard/aiguard.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aiguard reports OpenAgent API activity to an AIGuard instance.
+package aiguard
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"github.com/the-open-agent/openagent/conf"
+	"github.com/the-open-agent/openagent/object"
+)
+
+const aiguardRecordEventType = "api"
+
+var aiguardHTTPClient = &http.Client{Timeout: 3 * time.Second}
+
+type aiguardRecord struct {
+	Agent       string `json:"agent"`
+	CreatedTime string `json:"createdTime"`
+	EventType   string `json:"eventType"`
+	Action      string `json:"action"`
+	Outcome     string `json:"outcome"`
+	User        string `json:"user,omitempty"`
+}
+
+type aiguardResponse struct {
+	Status string `json:"status"`
+	Msg    string `json:"msg"`
+}
+
+// SubmitRecord asynchronously reports a sanitized OpenAgent record when
+// aiguardEndpoint is configured.
+func SubmitRecord(record *object.Record) {
+	endpoint := strings.TrimSpace(conf.GetConfigString("aiguardEndpoint"))
+	if endpoint == "" || record == nil {
+		return
+	}
+
+	aiguardRecord := newAIGuardRecord(record)
+	go func() {
+		err := postAIGuardRecord(endpoint, aiguardRecord)
+		if err != nil {
+			logs.Warning("aiguard.SubmitRecord() error: %s", err.Error())
+		}
+	}()
+}
+
+func newAIGuardRecord(record *object.Record) *aiguardRecord {
+	outcome := "failure"
+	response := &object.Response{}
+	if err := json.Unmarshal([]byte(record.Response), response); (err == nil && response.Status == "ok") ||
+		strings.HasPrefix(record.Response, `{"status":"ok",`) {
+		outcome = "success"
+	}
+
+	return &aiguardRecord{
+		Agent:       "openagent",
+		CreatedTime: record.CreatedTime,
+		EventType:   aiguardRecordEventType,
+		Action:      record.Action,
+		Outcome:     outcome,
+		User:        record.User,
+	}
+}
+
+func postAIGuardRecord(endpoint string, record *aiguardRecord) error {
+	body, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+
+	url := strings.TrimRight(endpoint, "/") + "/api/records"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := aiguardHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("AIGuard returned HTTP status %d", resp.StatusCode)
+	}
+
+	result := &aiguardResponse{}
+	if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return err
+	}
+	if result.Status != "ok" {
+		return fmt.Errorf("AIGuard returned status %q: %s", result.Status, result.Msg)
+	}
+
+	return nil
+}

--- a/aiguard/aiguard_test.go
+++ b/aiguard/aiguard_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aiguard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/the-open-agent/openagent/object"
+)
+
+func TestSubmitRecordDisabled(t *testing.T) {
+	t.Setenv("aiguardEndpoint", "")
+
+	SubmitRecord(&object.Record{Action: "update-store"})
+}
+
+func TestSubmitRecord(t *testing.T) {
+	requestBody := make(chan map[string]interface{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/records" {
+			t.Errorf("expected /api/records, got %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json content type, got %s", r.Header.Get("Content-Type"))
+		}
+
+		payload := map[string]interface{}{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		requestBody <- payload
+		_, _ = w.Write([]byte(`{"status":"ok","msg":"","data":null}`))
+	}))
+	defer server.Close()
+	t.Setenv("aiguardEndpoint", server.URL+"/")
+
+	SubmitRecord(&object.Record{
+		CreatedTime: "2026-07-23T12:00:00.000+08:00",
+		Action:      "update-store",
+		User:        "alice",
+		Object:      `{"prompt":"secret prompt","accessToken":"secret token"}`,
+		Response:    `{"status":"ok","msg":"secret response"}`,
+	})
+
+	select {
+	case payload := <-requestBody:
+		if len(payload) != 6 {
+			t.Fatalf("expected 6 safe fields, got %d: %#v", len(payload), payload)
+		}
+		expected := map[string]string{
+			"agent":       "openagent",
+			"createdTime": "2026-07-23T12:00:00.000+08:00",
+			"eventType":   aiguardRecordEventType,
+			"action":      "update-store",
+			"outcome":     "success",
+			"user":        "alice",
+		}
+		for key, value := range expected {
+			if payload[key] != value {
+				t.Errorf("expected %s=%q, got %#v", key, value, payload[key])
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for AIGuard request")
+	}
+}
+
+func TestSubmitRecordDoesNotBlock(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		_, _ = w.Write([]byte(`{"status":"ok","msg":"","data":null}`))
+	}))
+	defer server.Close()
+	t.Setenv("aiguardEndpoint", server.URL)
+
+	start := time.Now()
+	SubmitRecord(&object.Record{Response: `{"status":"ok","msg":""}`})
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("SubmitRecord blocked for %v", elapsed)
+	}
+
+	select {
+	case <-requestStarted:
+		close(releaseRequest)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for asynchronous AIGuard request")
+	}
+}
+
+func TestPostAIGuardRecordHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	err := postAIGuardRecord(server.URL, &aiguardRecord{Agent: "openagent"})
+	if err == nil || !strings.Contains(err.Error(), "HTTP status 503") {
+		t.Fatalf("expected HTTP status error, got %v", err)
+	}
+}
+
+func TestPostAIGuardRecordStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"error","msg":"rejected"}`))
+	}))
+	defer server.Close()
+
+	err := postAIGuardRecord(server.URL, &aiguardRecord{Agent: "openagent"})
+	if err == nil || !strings.Contains(err.Error(), "rejected") {
+		t.Fatalf("expected AIGuard status error, got %v", err)
+	}
+}

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -12,4 +12,5 @@ clientSecret =
 ipParsingMode = ""
 parentDbName = ""
 socks5Proxy = "127.0.0.1:10808"
+aiguardEndpoint =
 logConfig = {"adapter":"file", "filename": "logs/openagent.log", "maxdays":99999, "perm":"0770"}

--- a/routers/record.go
+++ b/routers/record.go
@@ -17,6 +17,7 @@ package routers
 import (
 	"github.com/beego/beego/context"
 	"github.com/beego/beego/logs"
+	"github.com/the-open-agent/openagent/aiguard"
 	"github.com/the-open-agent/openagent/object"
 	"github.com/the-open-agent/openagent/util"
 )
@@ -47,4 +48,5 @@ func AfterRecordMessage(ctx *context.Context) {
 	}
 
 	object.AddRecord(record, "en")
+	aiguard.SubmitRecord(record)
 }


### PR DESCRIPTION
Closes #2466.

## Summary

- add optional `aiguardEndpoint` configuration
- asynchronously submit sanitized API records to AIGuard
- use the existing `/api/records` ingest endpoint
- keep AIGuard failures isolated from OpenAgent requests
- add tests for disabled, success, non-blocking, HTTP error, and API error cases

## Testing

- `go test ./aiguard ./routers -count=1`
- `go test ./aiguard -count=10`
- `go test -tags skipCi -vet=off ./...`
- `git diff --check`

## Notes

The full Windows vet run still reports the repository's existing `possible misuse of unsafe.Pointer` warning in `tool/windows_uia/win32.go`.