### PR TITLE
feat: record the version so it can be read without running the server

### DIFF
--- a/internal/cli/versionfile.go
+++ b/internal/cli/versionfile.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteVersionFile records this build's version in a plain "version" file next
+// to the binary, so an external tool can read the version without starting or
+// querying the server. The official release binaries are built with -trimpath
+// and packed with UPX, which erases the version from the Go build metadata; a
+// running binary still knows its own version, so writing it once on startup is
+// what makes it recoverable offline.
+//
+// It is best-effort - a failure never affects startup - and only writes a real
+// version, since a plain "dev" build has nothing worth recording. The location
+// mirrors where the SQLite database lives (next to the executable).
+func WriteVersionFile() {
+	if Version == "" || Version == "dev" {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	_ = os.WriteFile(filepath.Join(filepath.Dir(exe), "version"), []byte(Version+"\n"), 0o644)
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ func main() {
 		os.Exit(code)
 	}
 
+	cli.WriteVersionFile()
+
 	object.InitFlag()
 	object.InitAdapter()
 	object.CreateTables()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -52,6 +52,11 @@ try {
 
     Write-Info "Installing to $InstallDir ..."
     Copy-Item -Path $ExePath -Destination (Join-Path $InstallDir 'openagent.exe') -Force
+
+    # Record the version so it can be read without running the binary. The release
+    # binary is built with -trimpath and packed with UPX, which erases the version
+    # from its Go build metadata. WriteAllText writes UTF-8 with no BOM.
+    [System.IO.File]::WriteAllText((Join-Path $InstallDir 'version'), "$Version`n")
 }
 finally {
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,6 +78,15 @@ else
 	sudo chmod 755 "${INSTALL_DIR}/openagent"
 fi
 
+# ── record the version so it can be read without running the binary ────────────
+# The release binary is built with -trimpath and packed with UPX, which erases
+# the version from its Go build metadata, so record it next to the binary here.
+if [[ -w "${INSTALL_DIR}" ]]; then
+	printf '%s\n' "${OPENAGENT_VERSION}" > "${INSTALL_DIR}/version"
+else
+	printf '%s\n' "${OPENAGENT_VERSION}" | sudo tee "${INSTALL_DIR}/version" >/dev/null
+fi
+
 # ── add binary to PATH via BIN_DIR symlink ────────────────────────────────────
 mkdir -p "${BIN_DIR}"
 if [[ -w "${BIN_DIR}" ]]; then


### PR DESCRIPTION
## What
Make the running build's version recoverable from disk without starting or querying the server. The release binaries are built with -trimpath and packed with UPX, which erases the version from the Go build metadata, so record it in a plain "version" file next to the binary instead.
## Changes
- cli.WriteVersionFile writes the version on startup (covers a binary that has been run at least once), best-effort so a failure never affects startup and only a real version is written - a plain "dev" build has nothing to record.
- install.sh / install.ps1 write the resolved release tag at install time (covers a binary installed but not yet run). install.sh mirrors the existing sudo fallback; install.ps1 writes UTF-8 without a BOM.

The file lives next to the binary, the same directory the SQLite database uses.